### PR TITLE
Execute On Aggregate Default Value

### DIFF
--- a/Engine/RecordService.cs
+++ b/Engine/RecordService.cs
@@ -153,7 +153,7 @@ namespace MarkTek.Fluent.Testing.RecordGeneration
             });
         }
 
-        public IRecordService<TID> ExecuteAction(IExecutableAction<TID> implementation, bool executeAgainstAggregate)
+        public IRecordService<TID> ExecuteAction(IExecutableAction<TID> implementation, bool executeAgainstAggregate = false)
         {
             this.policy.Execute(() =>
             {


### PR DESCRIPTION
In RecordService.cs, updated the ExecuteAction executeAgainstAggregate parameter to have a default value so it is optional