### PR TITLE
Added policy parameter for WaitFor method

### DIFF
--- a/Engine/Interfaces/IRecordService.cs
+++ b/Engine/Interfaces/IRecordService.cs
@@ -1,5 +1,6 @@
 ﻿using Marktek.Fluent.Testing.Engine;
 using Marktek.Fluent.Testing.Engine.Interfaces;
+using Polly;
 using System;
 using System.Collections.Generic;
 
@@ -24,6 +25,14 @@ namespace MarkTek.Fluent.Testing.RecordGeneration
         /// <param name="implemetation"></param>
         /// <returns></returns>
         IRecordService<TID> WaitFor(IWaitableAction implemetation);
+
+        /// <summary>
+        /// Performs an action and waits for it to complete before proceeding.
+        /// </summary>
+        /// <param name="implemetation"></param>
+        /// <param name="policy"></param>
+        /// <returns></returns>
+        IRecordService<TID> WaitFor(IWaitableAction implemetation, Policy policy);
 
         /// <summary>
         /// Sets the aggregate Id to be the record that was last created

--- a/Engine/RecordService.cs
+++ b/Engine/RecordService.cs
@@ -189,6 +189,21 @@ namespace MarkTek.Fluent.Testing.RecordGeneration
         }
 
         /// <summary>
+        /// Waits for the waitable action to complete before proceeding.
+        /// </summary>
+        /// <param name="implementation"></param>
+        /// <param name="policy"></param>
+        /// <returns></returns>
+        public IRecordService<TID> WaitFor(IWaitableAction implementation, Policy policy)
+        {
+            policy.Execute(() =>
+            {
+                implementation.Execute();
+            });
+            return this;
+        }
+
+        /// <summary>
         /// Set the Aggregate id on the fly
         /// </summary>
         /// <returns></returns>

--- a/Marktek.Fluent.Testing.Engine.Tests/Integration/Implementations/DummyWaitForWithCustomPolicy.cs
+++ b/Marktek.Fluent.Testing.Engine.Tests/Integration/Implementations/DummyWaitForWithCustomPolicy.cs
@@ -1,0 +1,14 @@
+﻿using Marktek.Fluent.Testing.Engine.Interfaces;
+
+namespace Marktek.Fluent.Testing.Engine.Tests
+{
+    internal class DummyWaitForWithCustomPolicy : IWaitableAction
+    {
+        private int attempt = 0;
+        public void Execute()
+        {
+            attempt++;
+            if (attempt < 4) throw new System.Exception("Error");
+        }
+    }
+}

--- a/Marktek.Fluent.Testing.Engine.Tests/Integration/RecordServiceTests.cs
+++ b/Marktek.Fluent.Testing.Engine.Tests/Integration/RecordServiceTests.cs
@@ -133,6 +133,19 @@ namespace Marktek.Fluent.Testing.Engine.Tests
             service.GetRecordCount().Should().Be(0);
         }
 
+        [TestMethod]
+        public void Can_Run_WaitFor_Code_With_Policy()
+        {
+            Policy testPolicy = Policy
+               .Handle<Exception>()
+               .WaitAndRetry(4, retryAttempt => TimeSpan.FromSeconds(1));
+
+            service
+              .WaitFor(new DummyWaitForWithCustomPolicy(), testPolicy);
+
+            service.GetRecordCount().Should().Be(0);
+        }
+
         [DataTestMethod]
         [DataRow(1)]
         [DataRow(0)]

--- a/Marktek.Fluent.Testing.Engine.Tests/Marktek.Fluent.Testing.Engine.Tests.csproj
+++ b/Marktek.Fluent.Testing.Engine.Tests/Marktek.Fluent.Testing.Engine.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Integration\Implementations\DummyAssertionExample.cs" />
     <Compile Include="Integration\Implementations\DummyCleanup.cs" />
     <Compile Include="Integration\Implementations\DummyPreExecute.cs" />
+    <Compile Include="Integration\Implementations\DummyWaitForWithCustomPolicy.cs" />
     <Compile Include="Integration\Implementations\DummyWaitFor.cs" />
     <Compile Include="Integration\Implementations\EnsureAggregateIdMatches.cs" />
     <Compile Include="Integration\Implementations\ExecuteDummyAction.cs" />


### PR DESCRIPTION
Allows the passing in of a Policy as a parameter for WaitFor when there are specific scenarios where a different policy might be required for a Waitable Action.